### PR TITLE
fix authentication call if token already stored

### DIFF
--- a/dropbox.js
+++ b/dropbox.js
@@ -121,7 +121,7 @@
       if(isFunction(handlers.onComplete))
         handlers.onComplete();
       
-        if(Promise)
+      if(Promise)
         return Promise.resolve()
     }
 

--- a/dropbox.js
+++ b/dropbox.js
@@ -115,6 +115,16 @@
   dropbox.authenticate = function(apiArgs, handlers){
     handlers = handlers || {};
     if(isFunction(handlers)) handlers = { onComplete: handlers };
+
+    // if we already have an access token, return immediately
+    if( tokenStore('__dbat') ){
+      if(isFunction(handlers.onComplete))
+        handlers.onComplete();
+      
+        if(Promise)
+        return Promise.resolve()
+    }
+
     apiArgs = apiArgs || {};
     if(isString(apiArgs)) apiArgs = { client_id: apiArgs };
     apiArgs.redirect_uri = apiArgs.redirect_uri || window.location.href;
@@ -122,13 +132,6 @@
     var promise,promisectl = {};
     if(Promise){
       promise = new Promise(function(resolve,reject){ promisectl.resolve = resolve; promisectl.reject = reject });
-    }
-
-    // if we already have an access token, return immediately
-    if( tokenStore('__dbat') ){
-      handlers.onComplete();
-      promise && promise.resolve && promise.resolve();
-      return promise
     }
 
     var params = paramsFromUrlHash(),


### PR DESCRIPTION
Currently if no handles provided it fail with ref not found error because of call: 

`
handlers.onComplete();
`